### PR TITLE
Feature - VOD Theatre Mode

### DIFF
--- a/common/js/injected.js
+++ b/common/js/injected.js
@@ -12,3 +12,41 @@
     }, 200);
   }
 })();
+
+var keys = {};
+// Track what keys are being pressed
+$(document).keydown(function (e) {
+  keys[e.which] = true;
+  handleKeyPresses();
+});
+// Delete keys once they are not being pressed
+$(document).keyup(function (e) {
+  delete keys[e.which];
+  handleKeyPresses();
+});
+
+// Do our application specific key handles
+function handleKeyPresses() {
+  // esc to exit theatre mode
+  // Note twitch handles the player exit
+  if (keys[27]) {
+    $('#player').addClass('dynamic-player');
+  }
+  // alt+t to toggle theatre mode
+  // Note that twitch already handles the player toggle call
+  if (keys[18] && keys[84]) {
+    $('#player').toggleClass('dynamic-player');
+  }
+}
+
+// This function handles the theatre mode button click
+function handleTheatreMode() {
+  // Check that we have the twitch ember app
+  // Check that we are on the vod page route
+  if(!window.Ember || !window.App || App.__container__.lookup("controller:application").get("currentRouteName") !== "vod") {
+    return;
+  }
+  // Toggle our elements
+  App.__container__.lookup('controller:channel').send('toggleTheatre');
+  $('#player').toggleClass('dynamic-player');
+}

--- a/common/js/injected.js
+++ b/common/js/injected.js
@@ -18,7 +18,7 @@ $(document).keydown(function (e) {
   var key = String.fromCharCode(event.which).toLowerCase();
   // alt+t to toggle theatre mode
   // Note that twitch already handles the player toggle call
-  if ((e.altKey || e.metaKey) && key == 't') {
+  if (e.altKey && key == 't') {
     $('#player').toggleClass('dynamic-player');
   }
   // esc to exit theatre mode

--- a/common/js/injected.js
+++ b/common/js/injected.js
@@ -27,6 +27,11 @@ $(document).keyup(function (e) {
 
 // Do our application specific key handles
 function handleKeyPresses() {
+  // Check that we have the twitch ember app
+  // Check that we are on the vod page route
+  if(!window.Ember || !window.App || App.__container__.lookup("controller:application").get("currentRouteName") !== "vod") {
+    return;
+  }
   // esc to exit theatre mode
   // Note twitch handles the player exit
   if (keys[27]) {

--- a/common/js/injected.js
+++ b/common/js/injected.js
@@ -13,36 +13,20 @@
   }
 })();
 
-var keys = {};
-// Track what keys are being pressed
 $(document).keydown(function (e) {
-  keys[e.which] = true;
-  handleKeyPresses();
-});
-// Delete keys once they are not being pressed
-$(document).keyup(function (e) {
-  delete keys[e.which];
-  handleKeyPresses();
-});
-
-// Do our application specific key handles
-function handleKeyPresses() {
-  // Check that we have the twitch ember app
-  // Check that we are on the vod page route
-  if(!window.Ember || !window.App || App.__container__.lookup("controller:application").get("currentRouteName") !== "vod") {
-    return;
+  // Get the current key pressed
+  var key = String.fromCharCode(event.which).toLowerCase();
+  // alt+t to toggle theatre mode
+  // Note that twitch already handles the player toggle call
+  if ((e.altKey || e.metaKey) && key == 't') {
+    $('#player').toggleClass('dynamic-player');
   }
   // esc to exit theatre mode
   // Note twitch handles the player exit
-  if (keys[27]) {
+  if(e.keyCode == 27) {
     $('#player').addClass('dynamic-player');
   }
-  // alt+t to toggle theatre mode
-  // Note that twitch already handles the player toggle call
-  if (keys[18] && keys[84]) {
-    $('#player').toggleClass('dynamic-player');
-  }
-}
+});
 
 // This function handles the theatre mode button click
 function handleTheatreMode() {

--- a/common/js/rechat.js
+++ b/common/js/rechat.js
@@ -105,6 +105,13 @@ ReChat.Playback.prototype._prepareInterface = function() {
   this._container = container;
   $('body').append(container);
 
+  // Channel share button
+  var shareChannel = $('.channel-actions').find('span:last-child').prev();
+  // Add theatre button after
+  shareChannel.append('<span id="rechat-theatre-button" class="theatre-button glyph-only button action tooltip" onClick="handleTheatreMode()" original-title="Theater Mode (Alt+T)"><svg class="svg-theatre" height="16px" version="1.1" viewbox="0 0 16 16" width="16px" x="0px" y="0px"><path clip-rule="evenodd" d="M1,13h9V3H1V13z M11,3v10h4V3H11z" fill-rule="evenodd"></path></svg></span>');
+  // Add exit theatre button to player
+  $('#player').append('<div class="exit-theatre" onClick="handleTheatreMode()"><a data-ember-action="3984">Exit Theater Mode</a></div>');
+
   var rightCol = $('#right_col'),
       resizeCallback = function(mutations) {
         var styleChanged = false;


### PR DESCRIPTION
Adds the theatre mode to the vod page.
I really liked having the theatre mode to remove the clutter from the page.

Works like normal theatre mode including:
- Added theatre mode button
- Added "Exit Theatre Mode" button
- Working esc key exit
- Working Alt+T toggle

I was not sure about the best place for placing listeners and the such, and this is just what I have working. Feel free to change anything you want, but the functions need to reside in the `injected.js` so the page scope can see them.