### PR TITLE
Support Twitch's Dark Chat (which is also used by FrankerFaceZ's Dark Twitch)

### DIFF
--- a/common/js/rechat.js
+++ b/common/js/rechat.js
@@ -38,6 +38,12 @@ ReChat.Playback.prototype._prepareInterface = function() {
   var containerTab = $('#right_col .rightcol-content .tab-container').not('.hidden').first();
   var containerChat = $('<div>').addClass('chat-container js-chat-container');
 
+  var ember_settings = window.App && App.__container__.lookup('controller:settings');
+
+  if ( ember_settings.get('modal.darkMode') ) {
+    containerChat.addClass('dark');
+  }
+
   var containerEmber = $('<div>').css({
     'z-index': 4,
     'margin': 0


### PR DESCRIPTION
This change makes ReChat check to see if it should be darkening chat and apply the necessary class to the chat container in that event.