### PR TITLE
Support Twitch's Dark Chat Option

### DIFF
--- a/common/js/rechat.js
+++ b/common/js/rechat.js
@@ -26,6 +26,16 @@ this.ReChat = $.extend({
   }
 }, this.ReChat || {});
 
+ReChat.EmberSettings = function() {
+  if ( localStorage.hasOwnProperty('chatSettings') ) {
+    try {
+      return JSON.parse(localStorage.chatSettings);
+    } catch(err) { }
+  }
+
+  return {showTimestamps: false, darkMode: false};
+}
+
 ReChat.BTTVDetected = function() {
   return $('script[src*="betterttv"]').length != 0;
 }
@@ -60,6 +70,11 @@ ReChat.Playback.prototype._prepareInterface = function() {
 
   var containerTab = $('#right_col .rightcol-content .tab-container').not('.hidden').first();
   var containerChat = $('<div>').addClass('chat-container js-chat-container');
+
+  var settings = ReChat.EmberSettings();
+  if ( settings.darkMode ) {
+    containerChat.addClass('dark');
+  }
 
   var containerEmber = $('<div>').css({
     'z-index': 4,


### PR DESCRIPTION
This adds a method to fetch Ember's settings from localStorage, which contains flags for showing timestamps and dark-mode chat. If darkMode is true, it should add the dark class to the chat-container.